### PR TITLE
Further tweaks to template HTML for increased readability/usability

### DIFF
--- a/core/templates/bug_mailtemplate.html
+++ b/core/templates/bug_mailtemplate.html
@@ -56,7 +56,7 @@ Available fields to this template:
             box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
         }
 
-        h2 {
+        h3 {
             color: #333;
             background: #f2f2f2;
             padding: 10px;
@@ -104,11 +104,23 @@ Available fields to this template:
 
 <body>
     <div class="container">
-        <h2>{{ top_line }}</h2>
+        <h3>{{ summary }}</h3>
         <table>
             <tr>
                 <th>Issue-id</th>
-                <td>{{ bug_id }} <a href="{{ url }}">View all details inside the Issue Tracker</a></td>
+                <td><a href={{ url }}>{{ bug_id }}</a></td>
+            </tr>
+            <tr>
+                <th>Description</th>
+                <td>{{ description }}</td>
+            </tr>
+            <tr>
+                <th>Project/Category</th>
+                <td>{{ project }}: {{ category }}</td>
+            </tr>
+			<tr>
+                <th>Reporter</th>
+                <td>{{ reporter }}</td>
             </tr>
             <tr>
                 <th>Status</th>
@@ -119,10 +131,6 @@ Available fields to this template:
                 <td>{{ submitted }}</td>
             </tr>
             <tr>
-                <th>Last Modified</th>
-                <td>{{ modified }}</td>
-            </tr>
-            <tr>
                 <th>Priority</th>
                 <td>{{ priority }}</td>
             </tr>
@@ -131,28 +139,12 @@ Available fields to this template:
                 <td>{{ severity }}</td>
             </tr>
             <tr>
+                <th>Last Modified</th>
+                <td>{{ modified }}</td>
+            </tr>
+            <tr>
                 <th>Reproducibility</th>
                 <td>{{ repro }}</td>
-            </tr>
-            <tr>
-                <th>Reporter</th>
-                <td>{{ reporter }}</td>
-            </tr>
-            <tr>
-                <th>Project</th>
-                <td>{{ project }}</td>
-            </tr>
-            <tr>
-                <th>Category</th>
-                <td>{{ category }}</td>
-            </tr>
-            <tr>
-                <th>Summary</th>
-                <td>{{ summary }}</td>
-            </tr>
-            <tr>
-                <th>Description</th>
-                <td>{{ description }}</td>
             </tr>
             <tr>
                 <th>Steps to reproduce</th>

--- a/core/templates/newbug_mailtemplate.html
+++ b/core/templates/newbug_mailtemplate.html
@@ -56,7 +56,7 @@ Available fields to this template:
             box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
         }
 
-        h2 {
+        h3 {
             color: #333;
             background: #f2f2f2;
             padding: 10px;
@@ -98,16 +98,29 @@ Available fields to this template:
         pre {
             white-space: pre-wrap;
             margin: 0;
-        }    </style>
+        }
+    </style>
 </head>
 
 <body>
     <div class="container">
-        <h2>{{ top_line }}</h2>
+        <h3>{{ summary }}</h3>
         <table>
             <tr>
                 <th>Issue-id</th>
-                <td>{{ bug_id }} <a href="{{ url }}">View all details inside the Issue Tracker</a></td>
+                <td><a href={{ url }}>{{ bug_id }}</a></td>
+            </tr>
+            <tr>
+                <th>Description</th>
+                <td>{{ description }}</td>
+            </tr>
+            <tr>
+                <th>Project/Category</th>
+                <td>{{ project }}: {{ category }}</td>
+            </tr>
+			<tr>
+                <th>Reporter</th>
+                <td>{{ reporter }}</td>
             </tr>
             <tr>
                 <th>Status</th>
@@ -118,10 +131,6 @@ Available fields to this template:
                 <td>{{ submitted }}</td>
             </tr>
             <tr>
-                <th>Last Modified</th>
-                <td>{{ modified }}</td>
-            </tr>
-            <tr>
                 <th>Priority</th>
                 <td>{{ priority }}</td>
             </tr>
@@ -130,28 +139,12 @@ Available fields to this template:
                 <td>{{ severity }}</td>
             </tr>
             <tr>
+                <th>Last Modified</th>
+                <td>{{ modified }}</td>
+            </tr>
+            <tr>
                 <th>Reproducibility</th>
                 <td>{{ repro }}</td>
-            </tr>
-            <tr>
-                <th>Reporter</th>
-                <td>{{ reporter }}</td>
-            </tr>
-            <tr>
-                <th>Project</th>
-                <td>{{ project }}</td>
-            </tr>
-            <tr>
-                <th>Category</th>
-                <td>{{ category }}</td>
-            </tr>
-            <tr>
-                <th>Summary</th>
-                <td>{{ summary }}</td>
-            </tr>
-            <tr>
-                <th>Description</th>
-                <td>{{ description }}</td>
             </tr>
             <tr>
                 <th>Steps to reproduce</th>

--- a/core/templates/note_mailtemplate.html
+++ b/core/templates/note_mailtemplate.html
@@ -40,7 +40,7 @@ Available fields to this template:
             box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
         }
 
-        h2 {
+        h3 {
             color: #333;
             background: #f2f2f2;
             padding: 10px;
@@ -88,7 +88,7 @@ Available fields to this template:
 
 <body>
     <div class="container">
-        <h2>{{ top_line }}</h2>
+        <h3>{{ summary }}</h3>
         <br>
         <table>
             <tr>
@@ -96,20 +96,20 @@ Available fields to this template:
                 <td><a href={{ url }}>{{ bug_id }}</a></td>
             </tr>
             <tr>
-                <th>Issue Summary</th>
-                <td>{{ summary }}</td>
-            </tr>
-            <tr>
                 <th>Project/Category</th>
                 <td>{{ project }}: {{ category }}</td>
             </tr>
             <tr>
-                <th>Note ID </th>
-                <td><a href={{ url }}>{{ note_id }}</a></td>
+                <th>Author</th>
+                <td>{{ reporter }}</td>
             </tr>
             <tr>
-                <th>Reporter</th>
-                <td>{{ reporter }}</td>
+                <th>Note</th>
+                <td><pre>{{ note }}</pre></td>
+            </tr>
+            <tr>
+                <th>Note ID </th>
+                <td><a href={{ url }}>{{ note_id }}</a></td>
             </tr>
             <tr>
                 <th>Access level</th>
@@ -126,10 +126,6 @@ Available fields to this template:
             <tr>
                 <th>Timetracking</th>
                 <td><pre>{{ timetrack }}</pre></td>
-            </tr>
-            <tr>
-                <th>Note</th>
-                <td><pre>{{ note }}</pre></td>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
- Reduced size of top line from `<h2>` to `<h3>`
- Added issue Summary to top line for quick reference as to what the note/bug is about
- Reordered html table rows in both Note and Bug template to move more important data towards the  top (which will be read first)
- Condensed the Project/Category rows into a single row